### PR TITLE
UI: Ensure "use for" options displayed when in landscape orientation

### DIFF
--- a/res/layout/device_profiles_settings.xml
+++ b/res/layout/device_profiles_settings.xml
@@ -52,10 +52,14 @@
         android:textAppearance="@android:style/TextAppearance.Material.Body1"
         android:textColor="?android:attr/textColorSecondary" />
 
-    <LinearLayout
-        android:id="@+id/profiles_section"
-        android:orientation="vertical"
+    <ScrollView
         android:layout_width="match_parent"
-        android:layout_height="wrap_content" />
+        android:layout_height="wrap_content">
+        <LinearLayout
+             android:id="@+id/profiles_section"
+             android:orientation="vertical"
+             android:layout_width="match_parent"
+             android:layout_height="wrap_content" />
+     </ScrollView>
 
 </LinearLayout>


### PR DESCRIPTION
Items under the "use for" section of the "Paired devices" dialog for
bluetooth connected headsets can be cut off on some devices when in
landscape mode.  This patch encloses those items in a ScrollView so
the user can scroll the off screen items into view and enable/disable
them.

[Procedures]
1.Go to Settings -> bluetooth
2.Paired with a bluetooth headset
3.Click on the setting of bluetooth headset
4.check the menu list and rotate the phone
5.and can not sliding the list

Change-Id: I52f4d494ca3c71a9ed88b2679868e77b092b4710
