### PR TITLE
InstalledAppDetails: fix refreshing storage summary after force stop

### DIFF
--- a/src/com/android/settings/applications/AppInfoBase.java
+++ b/src/com/android/settings/applications/AppInfoBase.java
@@ -156,7 +156,7 @@ public abstract class AppInfoBase extends SettingsPreferenceFragment
 
     @Override
     public void onRunningStateChanged(boolean running) {
-        // No op.
+        refreshUi();
     }
 
     @Override

--- a/src/com/android/settings/applications/InstalledAppDetails.java
+++ b/src/com/android/settings/applications/InstalledAppDetails.java
@@ -1021,7 +1021,6 @@ public class InstalledAppDetails extends AppInfoBase
         public void onReceive(Context context, Intent intent) {
             if (getActivity() != null && !getActivity().isDestroyed()) {
                 updateForceStopButton(getResultCode() != Activity.RESULT_CANCELED);
-                refreshUi();
             }
         }
     };


### PR DESCRIPTION
- if app is force stopped, current implementation causes a nasty loop which in turn causes
  very high cpu usage: refreshUi() > checkForceStop() > mCheckKillProcessesReceiver > refreshUi()
- fix storage not being updated by running refreshUi() in onRunningStateChanged from AppInfoBase

Ticket: CYNGNOS-2527

Change-Id: Iec24bb620d1a6287d7ccf583db978ef338ef762e
