### PR TITLE
Break out Bluetooth device icon from dashboard reference.

### DIFF
--- a/res/values/cm_drawables.xml
+++ b/res/values/cm_drawables.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (C) 2016 The CyanogenMod Project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<resources>
+
+    <!-- Default Bluetooth icon for subsettings -->
+    <drawable name="ic_bt_bluetooth">@drawable/ic_settings_bluetooth</drawable>
+
+</resources>

--- a/src/com/android/settings/bluetooth/BluetoothDevicePreference.java
+++ b/src/com/android/settings/bluetooth/BluetoothDevicePreference.java
@@ -284,7 +284,7 @@ public final class BluetoothDevicePreference extends Preference implements
                 return R.drawable.ic_bt_headset_hfp;
             }
         }
-        return R.drawable.ic_settings_bluetooth;
+        return R.drawable.ic_bt_bluetooth;
     }
 
     private final BroadcastReceiver mBluetoothReceiver = new BroadcastReceiver() {


### PR DESCRIPTION
If a theme wants to use a different visual iconography style in
the subsettings, the bluetooth icon is shared between the dashboard
and that view. By adding this new reference, a themer can choose to
independently theme the subsettings version if their design calls
for that.

Change-Id: Iac3a58175f90357e0c42efe57b1e698d5c8e2ad3
Ticket: CYNGNOS-3176
