### PR TITLE
Settings: Add adaptive display mode desc. strings

### DIFF
--- a/res/values/cm_strings.xml
+++ b/res/values/cm_strings.xml
@@ -705,6 +705,8 @@
     <string name="live_display_color_profile_photography_summary">Perfect color reproduction for photos</string>
     <string name="live_display_color_profile_basic_title">Basic</string>
     <string name="live_display_color_profile_basic_summary">Use the display uncalibrated</string>
+    <string name="live_display_color_profile_adaptive_title">Adaptive</string>
+    <string name="live_display_color_profile_adaptive_summary">Colors adapt to ambient conditions</string>
 
     <!-- Whether to display IME switcher notifcation -->
     <string name="ime_switcher_notify">Selector icon</string>


### PR DESCRIPTION
Samsung devices support an 'Adaptive' display mode, or more
commonly known as 'Auto'. Add the descriptions for this mode.

Change-Id: I8532c00b01c0adf5d8d4ff0baed13246937d1ced
