### PR TITLE
Settings: Always set ramp-up time value during bindView

### DIFF
--- a/src/com/android/settings/notification/IncreasingRingVolumePreference.java
+++ b/src/com/android/settings/notification/IncreasingRingVolumePreference.java
@@ -143,6 +143,8 @@ public class IncreasingRingVolumePreference extends Preference implements
         mStartVolumeSeekBar.setOnSeekBarChangeListener(this);
         mRampUpTimeSeekBar.setOnSeekBarChangeListener(this);
         mRampUpTimeSeekBar.setProgress((rampUpTime / 5) - 1);
+        mRampUpTimeValue.setText(
+                Formatter.formatShortElapsedTime(getContext(), rampUpTime * 1000));
     }
 
     @Override


### PR DESCRIPTION
onProgressChange is not always called if we set the
ramp up time to 5 sec (0 in seekbar value, since it is
the default value, no change).
Causing the text showing the ramp up time text value not
updated and display as empty when user enable/disable
increasing ring volume with ramp up time set to 5 sec.

FEIJ-1572

Change-Id: Id32d6b51aab05e80be59bc1912c4ae7c5d114ac5
