### PR TITLE
settings: Add support for color balance in LiveDisplay

### DIFF
--- a/src/com/android/settings/livedisplay/LiveDisplay.java
+++ b/src/com/android/settings/livedisplay/LiveDisplay.java
@@ -313,7 +313,9 @@ public class LiveDisplay extends SettingsPreferenceFragment implements
         int night = mLiveDisplayManager.getNightColorTemperature();
 
         mDisplayTemperature.setSummary(getResources().getString(
-                R.string.live_display_color_temperature_summary, day, night));
+                R.string.live_display_color_temperature_summary,
+                mDisplayTemperature.roundUp(day),
+                mDisplayTemperature.roundUp(night)));
     }
 
     @Override


### PR DESCRIPTION
- Use the newly exposed APIs to map color temperatures to
  the linear color balance range using a power curve
  calculation.

Change-Id: Ia1b7f26b5e4fff6d0f0e78d6cb62a7a9a2aec30e
